### PR TITLE
Do not check attributes for disabled indexes

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -743,6 +743,7 @@ module AlgoliaSearch
       return object.send(:algolia_dirty?) if (object.respond_to?(:algolia_dirty?))
       # Loop over each index to see if a attribute used in records has changed
       algolia_configurations.each do |options, settings|
+        next if algolia_indexing_disabled?(options)
         next if options[:slave] || options[:replica]
         return true if algolia_object_id_changed?(object, options)
         settings.get_attribute_names(object).each do |k|


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #340
| Need Doc update   | no


## Describe your change

If indexing is disabled, do not get all of the changed attributes

## What problem is this fixing?

In testing, we often have stubs that will break when trying to index. As a result we by
default set `disable_indexing: proc { Rails.env.test? }`. This is breaking after upgrading
algolia