### PR TITLE
Fix #352 and #353

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -953,8 +953,8 @@ module AlgoliaSearch
         return object.send("will_save_change_to_#{attr_name}?")
       end
 
-      # Nil means we don't know if the attribute has changed
-      nil
+      # We don't know if the attribute has changed, so conservatively assume it has
+      true
     end
 
     def automatic_changed_method?(object, method_name)
@@ -1018,7 +1018,9 @@ module AlgoliaSearch
     end
 
     def algolia_mark_must_reindex
-      @algolia_must_reindex =
+      # algolia_must_reindex flag is reset after every commit as part. If we must reindex at any point in
+      # a stransaction, keep flag set until it is explicitly unset
+      @algolia_must_reindex ||=
        if defined?(::Sequel) && is_a?(Sequel::Model)
          new? || self.class.algolia_must_reindex?(self)
        else


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #352 #353
| Need Doc update   | no

Fix breaking change introduced in #352
According to the [documentation](https://github.com/algolia/algoliasearch-rails/blob/master/README.md#custom-attribute-definition),
using custom attributes without a custom `_changed?` method will always
cause changes to push to the API. This behavior was lost in #338

Fix unexpected behavior during transactions #353
`@algolia_must_reindex` is reset in every validate call. This means that a record
that is updated multiple times in a transaction will only be indexed if the
final update marks as must reindex. Update the code so that once
`@algolia_must_reindex` is marked as `true`, it remains true until
explicitly unset in `algolia_perform_index_tasks`